### PR TITLE
schedule builds in ci on pushes and pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Wires
-
+# Wires [![Build Status](https://travis-ci.org/jgraham/wires.svg?branch=master)](https://travis-ci.org/jgraham/wires)
 
 WebDriver <-> Marionette proxy
 


### PR DESCRIPTION
This schedules builds on pushes and pull requests on stable, beta, and
nightly channels.  Builds on the nightly channel are allowed to fail,
which makes sense as an upfront warning that we need to fix something
in relative time but not block integration of new PRs.