### PR TITLE
Connect to IP-agnostic host "localhost".

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -933,7 +933,7 @@ impl MarionetteConnection {
         let poll_attempts = timeout / poll_interval;
         let mut poll_attempt = 0;
         loop {
-            match TcpStream::connect(&("127.0.0.1", self.port)) {
+            match TcpStream::connect(&("localhost", self.port)) {
                 Ok(stream) => {
                     self.stream = Some(stream);
                     break


### PR DESCRIPTION
The client should resolve whatever local address is available, rather
than using the a hard-coded IPv4 address. Marionette itself won't accept
an IPv6 connection yet,
however (https://bugzilla.mozilla.org/show_bug.cgi?id=1257719).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraham/wires/55)
<!-- Reviewable:end -->
