### PR TITLE
make GeckoContextParameters public

### DIFF
--- a/src/marionette.rs
+++ b/src/marionette.rs
@@ -107,7 +107,7 @@ impl ToJson for GeckoContext {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-struct GeckoContextParameters {
+pub struct GeckoContextParameters {
     context: GeckoContext
 }
 


### PR DESCRIPTION
Silences compiler warning E0446, whereby private types should not be
used in public interfaces.  In a future Rust release, not fixing this
will be a compile error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgraham/wires/57)
<!-- Reviewable:end -->
